### PR TITLE
Punica API IP address for notification callback registration

### DIFF
--- a/.pylint_conf
+++ b/.pylint_conf
@@ -206,7 +206,7 @@ ignore-on-opaque-inference=yes
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of
 # qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local,SQLObject,_socketobject,responses
+ignored-classes=optparse.Values,thread._local,_thread._local,SQLObject,_socketobject,responses,netifaces
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Sends request to register notification callback.
 ```python
 Service.check_notification_callback(self)
 ```
-Sends request to check whether or not notification
+Sends request to check whether or not notification callback is registered.
 
 Returns:
 object: notification callback data

--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ Shuts down socket listener
 Service.register_notification_callback(self)
 ```
 Sends request to register notification callback.
+### check_notification_callback
+```python
+Service.check_notification_callback(self)
+```
+Sends request to check whether or not notification
+
+Returns:
+object: notification callback data
+
 ### delete_notification_callback
 ```python
 Service.delete_notification_callback(self)

--- a/install_modules.sh
+++ b/install_modules.sh
@@ -1,2 +1,3 @@
+pip install netifaces
 pip install responses
 pip install PyEventEmitter

--- a/punica.py
+++ b/punica.py
@@ -57,7 +57,7 @@ class Service(event_emitter.EventEmitter):
         """Finds interface and sets IP address. Ignores loopback address.
 
         Returns:
-                str: IP address
+        str: IP address
         """
         ip = 'localhost'
         for iface_name in interfaces():
@@ -238,11 +238,8 @@ class Service(event_emitter.EventEmitter):
     def register_notification_callback(self):
         """Sends request to register notification callback."""
         try:
-            protocol = 'http'
-            if self.config['ca']:
-                protocol = 'https'
             data = {
-                'url':  protocol + '://' + self.ip + ':' + str(self.config['port']) + '/notification',
+                'url': 'http://' + self.ip + ':' + str(self.config['port']) + '/notification',
                 'headers': {}
             }
             content_type = 'application/json'

--- a/punica.py
+++ b/punica.py
@@ -234,9 +234,7 @@ class Service(event_emitter.EventEmitter):
         """Sends request to register notification callback."""
         try:
             data = {'url': 'http://' + self.ip_address + ':' +
-                           str(self.config['port']) + '/notification',
-                    'headers': {}
-                   }
+                           str(self.config['port']) + '/notification', 'headers': {}}
             content_type = 'application/json'
             response = self.put('/notification/callback', data, content_type)
             if response.status_code == 204:

--- a/punica.py
+++ b/punica.py
@@ -5,6 +5,7 @@ import socket
 import httplib
 import event_emitter
 import requests
+from netifaces import interfaces, ifaddresses, AF_INET
 
 
 class Service(event_emitter.EventEmitter):
@@ -30,6 +31,7 @@ class Service(event_emitter.EventEmitter):
         }
         if opts is not None:
             self.configure(opts)
+        self.ip = self.get_ip_address()
         self.authentication_token = ''
         self.token_validation = 3600
         self.pull_event = threading.Event()
@@ -50,6 +52,21 @@ class Service(event_emitter.EventEmitter):
         """
         for opt in opts:
             self.config[opt] = opts[opt]
+
+    def get_ip_address(self):
+        """Finds interface and sets IP address. Ignores loopback address.
+
+        Returns:
+                str: IP address
+        """
+        ip = 'localhost'
+        for iface_name in interfaces():
+            addresses = [i['addr'] for i in ifaddresses(
+                iface_name).setdefault(AF_INET, [{'addr': ''}])]
+            if addresses[0] and addresses[0] != '127.0.0.1':
+                ip = addresses[0]
+                break
+        return ip
 
     def start(self, opts=None):
         """(Re)starts authentication,
@@ -221,8 +238,11 @@ class Service(event_emitter.EventEmitter):
     def register_notification_callback(self):
         """Sends request to register notification callback."""
         try:
+            protocol = 'http'
+            if self.config['ca']:
+                protocol = 'https'
             data = {
-                'url': 'http://localhost:5725/notification',
+                'url':  protocol + '://' + self.ip + ':' + str(self.config['port']) + '/notification',
                 'headers': {}
             }
             content_type = 'application/json'

--- a/punica.py
+++ b/punica.py
@@ -246,6 +246,7 @@ class Service(event_emitter.EventEmitter):
 
     def check_notification_callback(self):
         """Sends request to check whether or not notification
+        callback is registered.
 
         Returns:
         object: notification callback data

--- a/tests/get_ip.py
+++ b/tests/get_ip.py
@@ -1,0 +1,12 @@
+from netifaces import interfaces, ifaddresses, AF_INET
+
+
+def get_ip_address():
+    ip = 'localhost'
+    for iface_name in interfaces():
+        addresses = [i['addr'] for i in ifaddresses(
+            iface_name).setdefault(AF_INET, [{'addr': ''}])]
+        if addresses[0] and addresses[0] != '127.0.0.1':
+            ip = addresses[0]
+            break
+    return ip

--- a/tests/lwm2m_tlv_test.py
+++ b/tests/lwm2m_tlv_test.py
@@ -1,5 +1,7 @@
 """ Tests for LwM2M TLV encoding, decoding methods """
 import unittest
+import sys
+sys.path.append('../')
 from tlv import RESOURCE_TYPE, TYPE, encode_resource_value, \
 	decode_resource_value, encode, decode, encode_resource, \
 	decode_resource, encode_resource_instance, \

--- a/tests/lwm2m_tlv_test.py
+++ b/tests/lwm2m_tlv_test.py
@@ -1,7 +1,5 @@
 """ Tests for LwM2M TLV encoding, decoding methods """
 import unittest
-import sys
-sys.path.append('../')
 from tlv import RESOURCE_TYPE, TYPE, encode_resource_value, \
 	decode_resource_value, encode, decode, encode_resource, \
 	decode_resource, encode_resource_instance, \

--- a/tests/punica_test.py
+++ b/tests/punica_test.py
@@ -241,7 +241,7 @@ class TestServiceMethods(unittest.TestCase):
         self.assertTrue(response == resp['notificationCallback'])
 
     @responses.activate
-    def test_get_notification_cb_https_return(self):
+    def test_get_notification_cb_https(self):
         """
         should return an object with valid notification callback data
         """
@@ -253,7 +253,7 @@ class TestServiceMethods(unittest.TestCase):
         self.assertTrue(response == resp['notificationCallbackHTTPS'])
 
     @responses.activate
-    def test_get_notification_cb_invalid(self):
+    def test_get_notification_cb_wrong(self):
         """
         should raise exception if notification callback doesnt match service parameters
         """
@@ -262,7 +262,7 @@ class TestServiceMethods(unittest.TestCase):
         with self.assertRaises(Exception):
             SERVICE.check_notification_callback()
 
-    def test_get_notification_cb_conn_fail(self):
+    def test_get_notification_cb_fail(self):
         """
         should raise exception if connection is not succesfull
         """

--- a/tests/punica_test.py
+++ b/tests/punica_test.py
@@ -233,29 +233,41 @@ class TestServiceMethods(unittest.TestCase):
     @responses.activate
     def test_get_notification_cb_return(self):
         """
-	should return an object with valid notification callback data
-	"""
-	responses.add(responses.GET, URL + '/notification/callback',
-			json=resp['notificationCallback'], status=200)
-	response = SERVICE.check_notification_callback()
-	self.assertTrue(response == resp['notificationCallback'])
+        should return an object with valid notification callback data
+        """
+        responses.add(responses.GET, URL + '/notification/callback',
+                      json=resp['notificationCallback'], status=200)
+        response = SERVICE.check_notification_callback()
+        self.assertTrue(response == resp['notificationCallback'])
+
+    @responses.activate
+    def test_get_notification_cb_https_return(self):
+        """
+        should return an object with valid notification callback data
+        """
+        responses.add(responses.GET, URL + '/notification/callback',
+                      json=resp['notificationCallbackHTTPS'], status=200)
+        SERVICE.configure({'ca': True})
+        response = SERVICE.check_notification_callback()
+        SERVICE.configure({'ca': False})
+        self.assertTrue(response == resp['notificationCallbackHTTPS'])
 
     @responses.activate
     def test_get_notification_cb_invalid(self):
         """
-	should raise exception if notification callback doesnt match service parameters
-	"""
-	responses.add(responses.GET, URL + '/notification/callback',
-			json=resp['badNotificationCallback'], status=200)
-	with self.assertRaises(Exception):
-	    SERVICE.check_notification_callback()
+        should raise exception if notification callback doesnt match service parameters
+        """
+        responses.add(responses.GET, URL + '/notification/callback',
+                      json=resp['badNotificationCallback'], status=200)
+        with self.assertRaises(Exception):
+            SERVICE.check_notification_callback()
 
     def test_get_notification_cb_conn_fail(self):
         """
         should raise exception if connection is not succesfull
         """
-	with self.assertRaises(Exception):
-	    SERVICE.check_notification_callback()
+        with self.assertRaises(Exception):
+            SERVICE.check_notification_callback()
 
     # ----------------------delete_notification_callback-------------------
     @responses.activate

--- a/tests/punica_test.py
+++ b/tests/punica_test.py
@@ -229,6 +229,35 @@ class TestServiceMethods(unittest.TestCase):
         with self.assertRaises(Exception):
             SERVICE.register_notification_callback()
 
+	# ----------------check_notification_callback------------------------
+	@responses.activate
+	def test_get_notification_cb_return(self):
+		"""
+		should return an object with valid notification callback data
+		"""
+		responses.add(responses.GET, URL + '/notification/callback',
+						json=resp['notificationCallback'], status=200)
+		response = SERVICE.check_notification_callback()
+		self.assertTrue(response == resp['notificationCallback'])
+
+	@responses.activate
+	def test_get_notification_cb_invalid(self):
+		"""
+		should raise exception if notification callback doesnt match service parameters
+		"""
+		responses.add(responses.GET, URL + '/notification/callback',
+						json=resp['badNotificationCallback'], status=200)
+		print(resp['badNotificationCallback']['url'])
+		with self.assertRaises(Exception):
+			SERVICE.check_notification_callback()
+
+	def test_get_notification_cb_conn_fail(self):
+			"""
+			should raise exception if connection is not succesfull
+			"""
+			with self.assertRaises(Exception):
+					SERVICE.check_notification_callback()
+
     # ----------------------delete_notification_callback-------------------
     @responses.activate
     def test_del_notification_cb_status(self):

--- a/tests/punica_test.py
+++ b/tests/punica_test.py
@@ -229,34 +229,33 @@ class TestServiceMethods(unittest.TestCase):
         with self.assertRaises(Exception):
             SERVICE.register_notification_callback()
 
-	# ----------------check_notification_callback------------------------
-	@responses.activate
-	def test_get_notification_cb_return(self):
-		"""
-		should return an object with valid notification callback data
-		"""
-		responses.add(responses.GET, URL + '/notification/callback',
-						json=resp['notificationCallback'], status=200)
-		response = SERVICE.check_notification_callback()
-		self.assertTrue(response == resp['notificationCallback'])
+    # ----------------check_notification_callback------------------------
+    @responses.activate
+    def test_get_notification_cb_return(self):
+        """
+	should return an object with valid notification callback data
+	"""
+	responses.add(responses.GET, URL + '/notification/callback',
+                        json=resp['notificationCallback'], status=200)
+	response = SERVICE.check_notification_callback()
+	self.assertTrue(response == resp['notificationCallback'])
 
-	@responses.activate
-	def test_get_notification_cb_invalid(self):
-		"""
-		should raise exception if notification callback doesnt match service parameters
-		"""
-		responses.add(responses.GET, URL + '/notification/callback',
-						json=resp['badNotificationCallback'], status=200)
-		print(resp['badNotificationCallback']['url'])
-		with self.assertRaises(Exception):
-			SERVICE.check_notification_callback()
+    @responses.activate
+    def test_get_notification_cb_invalid(self):
+	"""
+	should raise exception if notification callback doesnt match service parameters
+	"""
+	responses.add(responses.GET, URL + '/notification/callback',
+			json=resp['badNotificationCallback'], status=200)
+	    with self.assertRaises(Exception):
+	        SERVICE.check_notification_callback()
 
-	def test_get_notification_cb_conn_fail(self):
-			"""
-			should raise exception if connection is not succesfull
-			"""
-			with self.assertRaises(Exception):
-					SERVICE.check_notification_callback()
+    def test_get_notification_cb_conn_fail(self):
+        """
+        should raise exception if connection is not succesfull
+        """
+	with self.assertRaises(Exception):
+            SERVICE.check_notification_callback()
 
     # ----------------------delete_notification_callback-------------------
     @responses.activate

--- a/tests/punica_test.py
+++ b/tests/punica_test.py
@@ -236,26 +236,26 @@ class TestServiceMethods(unittest.TestCase):
 	should return an object with valid notification callback data
 	"""
 	responses.add(responses.GET, URL + '/notification/callback',
-                        json=resp['notificationCallback'], status=200)
+			json=resp['notificationCallback'], status=200)
 	response = SERVICE.check_notification_callback()
 	self.assertTrue(response == resp['notificationCallback'])
 
     @responses.activate
     def test_get_notification_cb_invalid(self):
-	"""
+        """
 	should raise exception if notification callback doesnt match service parameters
 	"""
 	responses.add(responses.GET, URL + '/notification/callback',
 			json=resp['badNotificationCallback'], status=200)
-	    with self.assertRaises(Exception):
-	        SERVICE.check_notification_callback()
+	with self.assertRaises(Exception):
+	    SERVICE.check_notification_callback()
 
     def test_get_notification_cb_conn_fail(self):
         """
         should raise exception if connection is not succesfull
         """
 	with self.assertRaises(Exception):
-            SERVICE.check_notification_callback()
+	    SERVICE.check_notification_callback()
 
     # ----------------------delete_notification_callback-------------------
     @responses.activate

--- a/tests/rest_response.py
+++ b/tests/rest_response.py
@@ -114,8 +114,14 @@ resp = {
             },
         ],
     },
-    'notificationCallback': { 'url': 'http://' + get_ip_address() +':5725/notification', 'headers': {} },
-    'notificationCallbackHTTPS': { 'url': 'https://' + get_ip_address() +':5725/notification', 'headers': {} },
+    'notificationCallback': {
+		      'url': 'http://' + get_ip_address() +':5725/notification',
+		      'headers': {}
+		      },
+    'notificationCallbackHTTPS': {
+		      'url': 'https://' + get_ip_address() +':5725/notification',
+		      'headers': {}
+		      },
     'badNotificationCallback': {'url': 'http://1.1.1.1:7777/notification', 'headers': {}},
     'registerCallback': '',
     'getEndpoints': [

--- a/tests/rest_response.py
+++ b/tests/rest_response.py
@@ -112,6 +112,8 @@ resp = {
             },
         ],
     },
+    # 'notificationCallback': { url: `http://${ip.address()}:5728/notification`, headers: {} },
+    'badNotificationCallback': {'url': 'http://1.1.1.1:7777/notification', 'headers': {}},
     'registerCallback': '',
     'getEndpoints': [
         {

--- a/tests/rest_response.py
+++ b/tests/rest_response.py
@@ -1,4 +1,6 @@
 """This module represesnts responses of punica server"""
+from get_ip import get_ip_address
+
 resp = {
     'authentication': {
         'access_token': 'eyJ0eXMiJ9.eyJppbiJ9.2HBtDz-bzdTPcYu-rNbwG-J9NC3P-f7kT6_YsNA',
@@ -112,7 +114,7 @@ resp = {
             },
         ],
     },
-    # 'notificationCallback': { url: `http://${ip.address()}:5728/notification`, headers: {} },
+    'notificationCallback': { 'url': 'http://' + get_ip_address() +':5725/notification', 'headers': {} },
     'badNotificationCallback': {'url': 'http://1.1.1.1:7777/notification', 'headers': {}},
     'registerCallback': '',
     'getEndpoints': [

--- a/tests/rest_response.py
+++ b/tests/rest_response.py
@@ -112,8 +112,6 @@ resp = {
             },
         ],
     },
-    # 'notificationCallback': { url: `http://${ip.address()}:5728/notification`, headers: {} },
-    'badNotificationCallback': {'url': 'http://1.1.1.1:7777/notification', 'headers': {}},
     'registerCallback': '',
     'getEndpoints': [
         {

--- a/tests/rest_response.py
+++ b/tests/rest_response.py
@@ -115,6 +115,7 @@ resp = {
         ],
     },
     'notificationCallback': { 'url': 'http://' + get_ip_address() +':5725/notification', 'headers': {} },
+    'notificationCallbackHTTPS': { 'url': 'https://' + get_ip_address() +':5725/notification', 'headers': {} },
     'badNotificationCallback': {'url': 'http://1.1.1.1:7777/notification', 'headers': {}},
     'registerCallback': '',
     'getEndpoints': [


### PR DESCRIPTION
*Punica API now gets it's IP address and sends it as argument for callback registration
*Added check_notification_callback() method which checks wether correct notification callback is registered
closes #8 